### PR TITLE
fix: MobX mutation actions

### DIFF
--- a/starport_template/lib/pages/routing_page.dart
+++ b/starport_template/lib/pages/routing_page.dart
@@ -37,7 +37,7 @@ class _RoutingPageState extends State<RoutingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: ContentStateSwitcher(
-        isLoading: StarportApp.walletsStore.areWalletsLoading.value,
+        isLoading: StarportApp.walletsStore.areWalletsLoading,
         isError: StarportApp.walletsStore.loadWalletsFailure.value != null,
         errorChild: const CosmosErrorView(
           title: "Something went wrong",

--- a/starport_template/lib/pages/wallet_details_page.dart
+++ b/starport_template/lib/pages/wallet_details_page.dart
@@ -3,6 +3,7 @@ import 'package:cosmos_ui_components/components/template/cosmos_balance_card.dar
 import 'package:cosmos_ui_components/components/template/cosmos_balance_heading.dart';
 import 'package:cosmos_ui_components/components/template/cosmos_wallets_list_view.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:mobx/mobx.dart';
 import 'package:starport_template/entities/balance.dart';
 import 'package:starport_template/entities/denom.dart';
@@ -21,11 +22,11 @@ class WalletDetailsPage extends StatefulWidget {
 class _WalletDetailsPageState extends State<WalletDetailsPage> {
   Observable<List<Balance>>? get balancesList => StarportApp.walletsStore.balancesList;
 
-  Observable<bool> get isBalancesLoading => StarportApp.walletsStore.isBalancesLoading;
+  bool get isBalancesLoading => StarportApp.walletsStore.isBalancesLoading;
 
-  Observable<bool> get isSendMoneyLoading => StarportApp.walletsStore.isSendMoneyLoading;
+  bool get isSendMoneyLoading => StarportApp.walletsStore.isSendMoneyLoading;
 
-  Observable<bool> get isError => StarportApp.walletsStore.isError;
+  bool get isError => StarportApp.walletsStore.isError;
 
   @override
   void initState() {
@@ -38,47 +39,49 @@ class _WalletDetailsPageState extends State<WalletDetailsPage> {
     return Scaffold(
       body: SafeArea(
         child: Center(
-          child: ContentStateSwitcher(
-            contentChild: Column(
-              children: [
-                ListTile(
-                  title: const Text('Wallet address'),
-                  subtitle: Text(widget.walletInfo.address),
-                ),
-                const Divider(),
-                const Padding(padding: EdgeInsets.only(top: 16)),
-                BalanceHeading(),
-                if (balancesList != null)
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Column(
-                      children: balancesList!.value
-                          .map(
-                            (balance) => BalanceCard(
-                              denomText: balance.denom.text,
-                              amountDisplayText: balance.amount.value.toString(),
-                              onTransferPressed: () => _transferPressed(balance),
-                            ),
-                          )
-                          .toList(),
-                    ),
+          child: Observer(
+            builder: (context) => ContentStateSwitcher(
+              contentChild: Column(
+                children: [
+                  ListTile(
+                    title: const Text('Wallet address'),
+                    subtitle: Text(widget.walletInfo.address),
                   ),
-                if (isSendMoneyLoading.value)
-                  const Padding(
-                    padding: EdgeInsets.only(top: 8.0),
-                    child: Center(
-                      child: Text(
-                        'Sending money',
-                        textAlign: TextAlign.center,
+                  const Divider(),
+                  const Padding(padding: EdgeInsets.only(top: 16)),
+                  BalanceHeading(),
+                  if (balancesList != null)
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        children: balancesList!.value
+                            .map(
+                              (balance) => BalanceCard(
+                                denomText: balance.denom.text,
+                                amountDisplayText: balance.amount.value.toString(),
+                                onTransferPressed: () => _transferPressed(balance),
+                              ),
+                            )
+                            .toList(),
                       ),
                     ),
-                  ),
-              ],
-            ),
-            isLoading: isBalancesLoading.value,
-            isError: isError.value,
-            errorChild: const Center(
-              child: Text('An unexpected error occurred'),
+                  if (isSendMoneyLoading)
+                    const Padding(
+                      padding: EdgeInsets.only(top: 8.0),
+                      child: Center(
+                        child: Text(
+                          'Sending money',
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              isLoading: isBalancesLoading,
+              isError: isError,
+              errorChild: const Center(
+                child: Text('An unexpected error occurred'),
+              ),
             ),
           ),
         ),

--- a/starport_template/lib/stores/wallets_store.dart
+++ b/starport_template/lib/stores/wallets_store.dart
@@ -1,3 +1,4 @@
+import 'package:alan/alan.dart' as alan;
 import 'package:mobx/mobx.dart';
 import 'package:starport_template/entities/balance.dart';
 import 'package:starport_template/utils/base_env.dart';
@@ -7,7 +8,6 @@ import 'package:transaction_signing_gateway/gateway/transaction_signing_gateway.
 import 'package:transaction_signing_gateway/model/credentials_storage_failure.dart';
 import 'package:transaction_signing_gateway/model/wallet_public_info.dart';
 import 'package:transaction_signing_gateway/transaction_signing_gateway.dart';
-import 'package:alan/alan.dart' as alan;
 import 'package:uuid/uuid.dart';
 
 class WalletsStore {
@@ -16,12 +16,32 @@ class WalletsStore {
 
   WalletsStore(this._transactionSigningGateway, this.baseEnv);
 
-  final Observable<bool> areWalletsLoading = Observable(false);
+  final Observable<bool> _areWalletsLoading = Observable(false);
 
-  final Observable<bool> isSendMoneyLoading = Observable(false);
-  final Observable<bool> isSendMoneyError = Observable(false);
-  final Observable<bool> isBalancesLoading = Observable(false);
-  final Observable<bool> isError = Observable(false);
+  final Observable<bool> _isSendMoneyLoading = Observable(false);
+  final Observable<bool> _isSendMoneyError = Observable(false);
+  final Observable<bool> _isBalancesLoading = Observable(false);
+  final Observable<bool> _isError = Observable(false);
+
+  bool get areWalletsLoading => _areWalletsLoading.value;
+
+  set areWalletsLoading(bool val) => Action(() => _areWalletsLoading.value = val)();
+
+  bool get isSendMoneyError => _isSendMoneyError.value;
+
+  set isSendMoneyError(bool val) => Action(() => _isSendMoneyError.value = val)();
+
+  bool get isSendMoneyLoading => _isSendMoneyLoading.value;
+
+  set isSendMoneyLoading(bool val) => Action(() => _isSendMoneyLoading.value = val)();
+
+  bool get isError => _isError.value;
+
+  set isError(bool val) => Action(() => _isError.value = val)();
+
+  bool get isBalancesLoading => _isBalancesLoading.value;
+
+  set isBalancesLoading(bool val) => Action(() => _isBalancesLoading.value = val)();
 
   final Observable<List<Balance>> balancesList = Observable([]);
 
@@ -30,23 +50,23 @@ class WalletsStore {
   Observable<List<WalletPublicInfo>> wallets = Observable([]);
 
   Future<void> loadWallets() async {
-    areWalletsLoading.value = true;
+    areWalletsLoading = true;
     (await _transactionSigningGateway.getWalletsList()).fold(
       (fail) => loadWalletsFailure.value = fail,
       (newWallets) => wallets.value = newWallets,
     );
-    areWalletsLoading.value = false;
+    areWalletsLoading = false;
   }
 
   Future<void> getBalances(String walletAddress) async {
-    isError.value = false;
-    isBalancesLoading.value = true;
+    isError = false;
+    isBalancesLoading = true;
     try {
       balancesList.value = await CosmosBalances(baseEnv).getBalances(walletAddress);
     } catch (error) {
-      isError.value = false;
+      isError = false;
     }
-    isBalancesLoading.value = false;
+    isBalancesLoading = false;
   }
 
   Future<WalletPublicInfo> importAlanWallet(
@@ -77,8 +97,8 @@ class WalletsStore {
     Balance balance,
     String toAddress,
   ) async {
-    isSendMoneyLoading.value = true;
-    isSendMoneyError.value = false;
+    isSendMoneyLoading = true;
+    isSendMoneyError = false;
     try {
       await TokenSender(_transactionSigningGateway).sendCosmosMoney(
         info,
@@ -86,8 +106,8 @@ class WalletsStore {
         toAddress,
       );
     } catch (ex) {
-      isError.value = true;
+      isError = true;
     }
-    isSendMoneyLoading.value = false;
+    isSendMoneyLoading = false;
   }
 }


### PR DESCRIPTION
We have to wrap the observable mutations into actions in order to not cause the `Side effects like changing state are not allowed at this point` type of errors