### PR TITLE
fix: Fix suffix widget for text field [Small fix]

### DIFF
--- a/packages/cosmos_ui_components/lib/components/cosmos_text_field.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_text_field.dart
@@ -73,7 +73,9 @@ class _CosmosTextFieldState extends State<CosmosTextField> {
         hintStyle: CosmosTextTheme.copy0Normal.copyWith(
           color: theme.colors.text.withOpacity(0.67),
         ),
-        suffix: widget.suffix == null ? _buildClearButton() : (controller.text.isEmpty ? null : _buildClearButton()),
+        suffix: widget.suffix == null
+            ? _buildClearButton()
+            : (controller.text.isEmpty ? widget.suffix : _buildClearButton()),
       ),
     );
   }


### PR DESCRIPTION
Fix "the passed suffix widget from outside never appears in the text field"