### PR TITLE
refactor: Add app_info_provider.dart

### DIFF
--- a/packages/cosmos_utils/lib/app_info_provider.dart
+++ b/packages/cosmos_utils/lib/app_info_provider.dart
@@ -1,0 +1,18 @@
+import 'package:cosmos_utils/app_info_extractor.dart';
+
+class AppInfoProvider {
+  Future<AppInfo> get appInfo async {
+    _appInfo ??= await getAppInfo();
+    return _appInfo!;
+  }
+
+  AppInfo? _appInfo;
+
+  Future<String> getAppVersion() async => (await appInfo).version;
+
+  Future<String> getAppName() async => (await appInfo).appName;
+
+  Future<String> getPackageName() async => (await appInfo).packageName;
+
+  Future<String> getBuildNumber() async => (await appInfo).buildNumber;
+}

--- a/packages/cosmos_utils/lib/cosmos_utils.dart
+++ b/packages/cosmos_utils/lib/cosmos_utils.dart
@@ -1,6 +1,7 @@
 library cosmos_utils;
 
 export 'address_parser.dart';
+export 'app_info_provider.dart';
 export 'colors_generator.dart';
 export 'extensions.dart';
 export 'future_either.dart';


### PR DESCRIPTION
Created a provider which provides all the data from `AppInfo` separately. Now the `AppInfo` class is also completely abstracted behind this provider. Let me know if this is a good approach. Also, I made a property so that it doesn't fetch the information again if it's already filled up after the first fetch.