### PR TITLE
fix: Remove throw from getter in transaction_signing_failure.dart

### DIFF
--- a/packages/transaction_signing_gateway/lib/model/transaction_signing_failure.dart
+++ b/packages/transaction_signing_gateway/lib/model/transaction_signing_failure.dart
@@ -39,7 +39,7 @@ class StorageProblemSigningFailure implements TransactionSigningFailure {
   final CredentialsStorageFailure failure;
 
   @override
-  TransactionSigningFailType get type => throw TransactionSigningFailType.walletCredentialsStorageFailure;
+  TransactionSigningFailType get type => TransactionSigningFailType.walletCredentialsStorageFailure;
 
   @override
   String toString() {


### PR DESCRIPTION
Fixes #186 