### PR TITLE
feat: add delete wallet to transaction_signing_gateway

### DIFF
--- a/packages/transaction_signing_gateway/lib/gateway/transaction_signing_gateway.dart
+++ b/packages/transaction_signing_gateway/lib/gateway/transaction_signing_gateway.dart
@@ -54,6 +54,10 @@ class TransactionSigningGateway {
         password: password,
       );
 
+  /// Deletes a wallet from device
+  Future<Either<CredentialsStorageFailure, Unit>> deleteWalletCredentials({required WalletPublicInfo publicInfo}) =>
+      _infoStorage.deleteWalletCredentials(publicInfo: publicInfo);
+
   /// Updates the public details of the wallet
   Future<Either<CredentialsStorageFailure, Unit>> updateWalletPublicInfo({
     required WalletPublicInfo info,

--- a/packages/transaction_signing_gateway/lib/storage/cosmos_key_info_storage.dart
+++ b/packages/transaction_signing_gateway/lib/storage/cosmos_key_info_storage.dart
@@ -121,6 +121,32 @@ class CosmosKeyInfoStorage implements KeyInfoStorage {
   }
 
   @override
+  Future<Either<CredentialsStorageFailure, Unit>> deleteWalletCredentials({
+    required WalletPublicInfo publicInfo,
+  }) async {
+    final credsKey = _credentialsKey(
+      chainId: publicInfo.chainId,
+      walletId: publicInfo.walletId,
+    );
+    final serializerKey = _serializerIdKey(
+      chainId: publicInfo.chainId,
+      walletId: publicInfo.walletId,
+    );
+    final publicInfoKey = _publicInfoKey(
+      chainId: publicInfo.chainId,
+      walletId: publicInfo.walletId,
+    );
+
+    return _secureDataStore.saveSecureText(key: credsKey, value: null).flatMap((_) {
+      return _plainDataStore.savePlainText(key: serializerKey, value: null);
+    }).flatMap((_) {
+      return _plainDataStore.savePlainText(key: publicInfoKey, value: null);
+    }).map((_) {
+      return right(unit);
+    });
+  }
+
+  @override
   Future<Either<CredentialsStorageFailure, List<WalletPublicInfo>>> getWalletsList() async =>
       _plainDataStore.readAllPlainText().flatMap(
         (storageMap) async {

--- a/packages/transaction_signing_gateway/lib/storage/key_info_storage.dart
+++ b/packages/transaction_signing_gateway/lib/storage/key_info_storage.dart
@@ -15,6 +15,8 @@ abstract class KeyInfoStorage {
     required String password,
   });
 
+  Future<Either<CredentialsStorageFailure, Unit>> deleteWalletCredentials({required WalletPublicInfo publicInfo});
+
   Future<Either<CredentialsStorageFailure, Unit>> updatePublicWalletInfo({
     required WalletPublicInfo info,
   });


### PR DESCRIPTION
Maybe I've missed it, but I could not find a way to delete the wallet from the device.
This PR is an attempt to solve that.