### PR TITLE
fix: (android) 🐛 bump up android and kotlin versions

### DIFF
--- a/starport_template/android/app/build.gradle
+++ b/starport_template/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId "com.starport.template"
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/starport_template/android/build.gradle
+++ b/starport_template/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
🐛 This PR will bump up android `compileSdkVersion` & `targetSdkVersion` to `31` and `kotlin_version` version to `1.5.10` and fix the CI Distribution failure