### PR TITLE
refactor: Add `toMap` and `fromMap` functions in `app_info_extractor.dart`

### DIFF
--- a/packages/cosmos_utils/lib/app_info_extractor.dart
+++ b/packages/cosmos_utils/lib/app_info_extractor.dart
@@ -23,4 +23,18 @@ class AppInfo {
   final String packageName;
   final String version;
   final String buildNumber;
+
+  AppInfo fromMap(Map<String, dynamic> json) => AppInfo(
+        packageName: json['packageName'] as String? ?? '',
+        appName: json['appName'] as String? ?? '',
+        buildNumber: json['buildNumber'] as String? ?? '',
+        version: json['version'] as String? ?? '',
+      );
+
+  Map<String, dynamic> toMap() => {
+        'appName': appName,
+        'packageName': packageName,
+        'version': version,
+        'buildNumber': buildNumber,
+      };
 }


### PR DESCRIPTION
Added these functions so that we can save some app version information to plain data storage