### PR TITLE
fix: cosmos_lint package name

### DIFF
--- a/packages/cosmos_lint/pubspec.yaml
+++ b/packages/cosmos_lint/pubspec.yaml
@@ -1,4 +1,4 @@
-name: lint
+name: cosmos_lint
 version: 1.9.0
 decription: Cosmos Linter
 homepage: ignite.com


### PR DESCRIPTION
This should fix a bug where `cosmos_lint ` was not named properly in `pubspec.yaml`