### PR TITLE
refactor: Add theme support for `CosmosElevatedButton` and `CosmosOutlinedButton`

### DIFF
--- a/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
@@ -36,8 +36,8 @@ class CosmosElevatedButton extends StatelessWidget {
     return ElevatedButton(
       onPressed: onTap,
       style: ElevatedButton.styleFrom(
-        primary: backgroundColor,
-        onPrimary: textColor,
+        primary: backgroundColor ?? theme.colors.background,
+        onPrimary: textColor ?? theme.colors.text,
         fixedSize: Size.fromHeight(height),
         shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
         elevation: elevation ?? 0,

--- a/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
@@ -36,8 +36,8 @@ class CosmosElevatedButton extends StatelessWidget {
     return ElevatedButton(
       onPressed: onTap,
       style: ElevatedButton.styleFrom(
-        primary: backgroundColor ?? theme.colors.background,
-        onPrimary: textColor ?? theme.colors.text,
+        onPrimary: backgroundColor ?? theme.colors.background,
+        primary: textColor ?? theme.colors.text,
         fixedSize: Size.fromHeight(height),
         shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
         elevation: elevation ?? 0,

--- a/packages/cosmos_ui_components/lib/components/cosmos_outline_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_outline_button.dart
@@ -23,9 +23,9 @@ class CosmosOutlineButton extends StatelessWidget {
     return OutlinedButton(
       onPressed: onTap,
       style: OutlinedButton.styleFrom(
-        backgroundColor: theme.colors.text,
-        primary: theme.colors.background,
-        side: BorderSide(color: theme.colors.background),
+        primary: theme.colors.text,
+        backgroundColor: theme.colors.background,
+        side: BorderSide(color: theme.colors.text),
         fixedSize: Size.fromHeight(height),
         shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
         elevation: 0,

--- a/packages/cosmos_ui_components/lib/components/cosmos_outline_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_outline_button.dart
@@ -19,11 +19,15 @@ class CosmosOutlineButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = CosmosTheme.of(context);
     return OutlinedButton(
       onPressed: onTap,
       style: OutlinedButton.styleFrom(
+        backgroundColor: theme.colors.text,
+        primary: theme.colors.background,
+        side: BorderSide(color: theme.colors.background),
         fixedSize: Size.fromHeight(height),
-        shape: RoundedRectangleBorder(borderRadius: CosmosTheme.of(context).borderRadiusM),
+        shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
         elevation: 0,
       ),
       child: Row(
@@ -31,7 +35,7 @@ class CosmosOutlineButton extends StatelessWidget {
         children: [
           Text(text),
           if (suffixIcon != null) ...[
-            SizedBox(width: CosmosTheme.of(context).spacingS),
+            SizedBox(width: theme.spacingS),
             suffixIcon!,
           ],
         ],


### PR DESCRIPTION
I just started converting our components to support CosmosTheme explicitly now, starting from elevated button and outlined button