### PR TITLE
refactor: Update theme support for `CosmosTextField`

### DIFF
--- a/packages/cosmos_ui_components/lib/components/cosmos_text_field.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_text_field.dart
@@ -88,9 +88,17 @@ class _CosmosTextFieldState extends State<CosmosTextField> {
         }
       },
       textAlign: widget.textAlign,
-      style: widget.style,
+      style: widget.style ??
+          CosmosTextTheme.copy0Normal.copyWith(
+            color: theme.colors.text,
+          ),
       decoration: InputDecoration(
         counterText: widget.maxLength == null ? null : '',
+        filled: true,
+        fillColor: theme.colors.chipBackground,
+        border: const OutlineInputBorder(
+          borderSide: BorderSide.none,
+        ),
         hintText: widget.hint,
         hintStyle: CosmosTextTheme.copy0Normal.copyWith(
           color: theme.colors.text.withOpacity(0.67),


### PR DESCRIPTION
Light:
<img width="375" alt="Screenshot 2022-05-11 at 11 32 47 AM" src="https://user-images.githubusercontent.com/25613623/167783998-45688396-3514-4198-88c4-1ae46ef26d48.png">

Dark:
<img width="375" alt="Screenshot 2022-05-11 at 11 32 56 AM" src="https://user-images.githubusercontent.com/25613623/167784024-899ac177-eeca-49c5-85c4-8a42d9a732d1.png">

