### PR TITLE
fix: [TxResponseTranslator extension] Fix parse timestamp property

### DIFF
--- a/packages/transaction_signing_gateway/lib/model/transaction_response.dart
+++ b/packages/transaction_signing_gateway/lib/model/transaction_response.dart
@@ -89,6 +89,6 @@ extension TxResponseTranslator on TxResponse {
         ),
         gasUsed: Decimal.parse('$gasUsed'),
         gasWanted: Decimal.parse('$gasWanted'),
-        timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(timestamp)),
+        timestamp: DateTime.fromMillisecondsSinceEpoch(int.tryParse(timestamp) ?? 0),
       );
 }


### PR DESCRIPTION
Use `int.tryParse(timestamp)` instead `int.parse(timestamp)`.

`int.parse(timestamp)` often throw an exception.
