### PR TITLE
fix: Fix disabled style for `CosmosElevatedButton`

### DIFF
--- a/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
@@ -34,7 +34,7 @@ class CosmosElevatedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = CosmosTheme.of(context);
     return ElevatedButton(
-      onPressed: onTap ?? () {},
+      onPressed: onTap,
       style: onTap == null ? _disabledStyle(context) : _enabledStyle(context),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -62,6 +62,7 @@ class CosmosElevatedButton extends StatelessWidget {
       splashFactory: NoSplash.splashFactory,
       onPrimary: backgroundColor ?? theme.colors.background,
       primary: textColor ?? theme.colors.inactive,
+      onSurface: theme.colors.inactive,
       fixedSize: Size.fromHeight(height),
       shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
       elevation: elevation ?? 0,

--- a/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
@@ -34,14 +34,15 @@ class CosmosElevatedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = CosmosTheme.of(context);
     return ElevatedButton(
-      onPressed: onTap,
+      onPressed: onTap ?? () {},
       style: ElevatedButton.styleFrom(
+        splashFactory: onTap == null ? NoSplash.splashFactory : null,
         onPrimary: backgroundColor ?? theme.colors.background,
-        primary: textColor ?? theme.colors.text,
+        primary: textColor ?? (onTap == null ? theme.colors.inactive : theme.colors.text),
         fixedSize: Size.fromHeight(height),
         shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
         elevation: elevation ?? 0,
-        shadowColor: shadowColor ?? theme.colors.shadowColor,
+        shadowColor: shadowColor ?? (onTap == null ? Colors.transparent : theme.colors.shadowColor),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
+++ b/packages/cosmos_ui_components/lib/components/cosmos_elevated_button.dart
@@ -35,15 +35,7 @@ class CosmosElevatedButton extends StatelessWidget {
     final theme = CosmosTheme.of(context);
     return ElevatedButton(
       onPressed: onTap ?? () {},
-      style: ElevatedButton.styleFrom(
-        splashFactory: onTap == null ? NoSplash.splashFactory : null,
-        onPrimary: backgroundColor ?? theme.colors.background,
-        primary: textColor ?? (onTap == null ? theme.colors.inactive : theme.colors.text),
-        fixedSize: Size.fromHeight(height),
-        shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
-        elevation: elevation ?? 0,
-        shadowColor: shadowColor ?? (onTap == null ? Colors.transparent : theme.colors.shadowColor),
-      ),
+      style: onTap == null ? _disabledStyle(context) : _enabledStyle(context),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -61,6 +53,31 @@ class CosmosElevatedButton extends StatelessWidget {
           ],
         ],
       ),
+    );
+  }
+
+  ButtonStyle _disabledStyle(context) {
+    final theme = CosmosTheme.of(context);
+    return ElevatedButton.styleFrom(
+      splashFactory: NoSplash.splashFactory,
+      onPrimary: backgroundColor ?? theme.colors.background,
+      primary: textColor ?? theme.colors.inactive,
+      fixedSize: Size.fromHeight(height),
+      shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
+      elevation: elevation ?? 0,
+      shadowColor: shadowColor ?? Colors.transparent,
+    );
+  }
+
+  ButtonStyle _enabledStyle(context) {
+    final theme = CosmosTheme.of(context);
+    return ElevatedButton.styleFrom(
+      onPrimary: backgroundColor ?? theme.colors.background,
+      primary: textColor ?? theme.colors.text,
+      fixedSize: Size.fromHeight(height),
+      shape: RoundedRectangleBorder(borderRadius: theme.borderRadiusM),
+      elevation: elevation ?? 0,
+      shadowColor: shadowColor ?? theme.colors.shadowColor,
     );
   }
 


### PR DESCRIPTION
`CosmosElevatedButton` was picking up disabled style from Flutter's theme because it uses onTap nullability to disable the button, which was causing the button to disappear in case of dark theme. Just fixed that.