### PR TITLE
fix: Remove input decoration theme from theme_converter.dart

### DIFF
--- a/packages/cosmos_ui_components/lib/utils/theme_converter.dart
+++ b/packages/cosmos_ui_components/lib/utils/theme_converter.dart
@@ -37,13 +37,6 @@ ThemeData convertCosmosThemeToMaterialTheme(CosmosThemeData theme) {
     disabledColor: theme.colors.inactive,
     dividerColor: theme.colors.divider,
     colorScheme: colorScheme,
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: theme.colors.chipBackground,
-      border: const OutlineInputBorder(
-        borderSide: BorderSide.none,
-      ),
-    ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ButtonStyle(
         backgroundColor: MaterialStateProperty.resolveWith((states) {


### PR DESCRIPTION
The `InputDecorationTheme` needed to be removed, as we only need some of the Flutter's theme properties and not all of them. In this case, `InputDecorationTheme` was implicitly being used by `PinPut` which showed our passcode screen like the image below since it used `TextField`s which use `InputDecorationTheme`. We will continue to see what properties to remove if they cause issues in the future as well.
![simulator_screenshot_6EC299AE-CD34-4EC7-89E2-B3BE61387FB5](https://user-images.githubusercontent.com/25613623/169041745-3397eb5b-ddaa-42ec-89a2-f57e36eb864a.png)

